### PR TITLE
feat: build WATI-like React chat with Tailwind

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Orvex Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "orvexchat",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.3.2",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { chats } from './mockData'
+
+export default function App() {
+  const [currentChat, setCurrentChat] = useState(chats[0])
+
+  return (
+    <div className="h-full flex">
+      <aside className="w-1/3 max-w-xs border-r border-gray-300">
+        <h2 className="p-4 font-semibold border-b border-gray-300">Chats</h2>
+        <ul>
+          {chats.map((chat) => (
+            <li
+              key={chat.id}
+              className={`p-4 cursor-pointer hover:bg-gray-100 ${
+                currentChat?.id === chat.id ? 'bg-gray-200' : ''
+              }`}
+              onClick={() => setCurrentChat(chat)}
+            >
+              {chat.name}
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <section className="flex-1 flex flex-col">
+        <header className="p-4 border-b border-gray-300">
+          {currentChat ? currentChat.name : 'Selecciona un chat'}
+        </header>
+        <div className="flex-1 p-4 overflow-y-auto flex flex-col gap-2">
+          {currentChat?.messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={`max-w-xs rounded-lg p-2 ${
+                msg.from === 'user'
+                  ? 'bg-gray-200 self-start'
+                  : 'bg-green-200 self-end'
+              }`}
+            >
+              {msg.text}
+            </div>
+          ))}
+        </div>
+        <footer className="p-4 border-t border-gray-300">
+          <input
+            type="text"
+            className="w-full border rounded p-2"
+            placeholder="Escribe un mensaje..."
+            disabled
+          />
+        </footer>
+      </section>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/src/mockData.js
+++ b/src/mockData.js
@@ -1,0 +1,18 @@
+export const chats = [
+  {
+    id: 1,
+    name: 'Juan Pérez',
+    messages: [
+      { id: 1, from: 'user', text: 'Hola, ¿en qué puedo ayudarte?' },
+      { id: 2, from: 'client', text: 'Necesito información sobre el producto.' },
+    ],
+  },
+  {
+    id: 2,
+    name: 'María García',
+    messages: [
+      { id: 1, from: 'user', text: 'Buenos días!' },
+      { id: 2, from: 'client', text: 'Hola, me gustaría saber más sobre su servicio.' },
+    ],
+  },
+]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- initialize Vite + React project
- configure TailwindCSS
- implement mock chat interface with conversation list and message panel

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_689d0b2dd4f8832a83b15821470da3dd