### PR TITLE
refactor: modularize chat and add routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/components/MessageInput.jsx
+++ b/src/components/MessageInput.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+
+export default function MessageInput({ onSend }) {
+  const [value, setValue] = useState('')
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    const text = value.trim()
+    if (!text) return
+    onSend(text)
+    setValue('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <input
+        type="text"
+        className="flex-1 border rounded p-2"
+        placeholder="Escribe un mensaje..."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button
+        type="submit"
+        className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        disabled={!value.trim()}
+      >
+        Enviar
+      </button>
+    </form>
+  )
+}

--- a/src/components/MessageItem.jsx
+++ b/src/components/MessageItem.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export default function MessageItem({ message }) {
+  const isUser = message.from === 'user'
+  return (
+    <div
+      className={`max-w-xs rounded-lg p-2 ${
+        isUser ? 'bg-gray-200 self-start' : 'bg-green-200 self-end'
+      }`}
+    >
+      {message.text}
+    </div>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App'
+import { RouterProvider } from 'react-router-dom'
+import { router } from './routes'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 )

--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -1,8 +1,27 @@
-import { useState } from 'react'
-import { chats } from './mockData'
+import { useEffect, useState } from 'react'
+import MessageItem from '../components/MessageItem'
+import MessageInput from '../components/MessageInput'
+import { getChats, sendMessage } from '../services/chatService'
 
-export default function App() {
-  const [currentChat, setCurrentChat] = useState(chats[0])
+export default function ChatPage() {
+  const [chats, setChats] = useState([])
+  const [currentChat, setCurrentChat] = useState(null)
+
+  useEffect(() => {
+    getChats().then((data) => {
+      setChats(data)
+      setCurrentChat(data[0] ?? null)
+    })
+  }, [])
+
+  const handleSend = async (text) => {
+    if (!currentChat) return
+    const updated = await sendMessage(currentChat.id, text)
+    setChats((prev) =>
+      prev.map((chat) => (chat.id === updated.id ? updated : chat)),
+    )
+    setCurrentChat(updated)
+  }
 
   return (
     <div className="h-full flex">
@@ -28,25 +47,11 @@ export default function App() {
         </header>
         <div className="flex-1 p-4 overflow-y-auto flex flex-col gap-2">
           {currentChat?.messages.map((msg) => (
-            <div
-              key={msg.id}
-              className={`max-w-xs rounded-lg p-2 ${
-                msg.from === 'user'
-                  ? 'bg-gray-200 self-start'
-                  : 'bg-green-200 self-end'
-              }`}
-            >
-              {msg.text}
-            </div>
+            <MessageItem key={msg.id} message={msg} />
           ))}
         </div>
         <footer className="p-4 border-t border-gray-300">
-          <input
-            type="text"
-            className="w-full border rounded p-2"
-            placeholder="Escribe un mensaje..."
-            disabled
-          />
+          <MessageInput onSend={handleSend} />
         </footer>
       </section>
     </div>

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { createBrowserRouter } from 'react-router-dom'
+import ChatPage from '../pages/ChatPage'
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <ChatPage />,
+  },
+])

--- a/src/services/chatService.js
+++ b/src/services/chatService.js
@@ -1,0 +1,23 @@
+import { chats as mockChats } from '../mockData'
+
+let chats = mockChats.map((chat) => ({
+  ...chat,
+  messages: [...chat.messages],
+}))
+
+export async function getChats() {
+  return chats
+}
+
+export async function sendMessage(chatId, text) {
+  const chat = chats.find((c) => c.id === chatId)
+  if (!chat) throw new Error('Chat not found')
+  const message = { id: Date.now(), from: 'user', text }
+  chat.messages = [...chat.messages, message]
+  return chat
+}
+
+export async function getMessages(chatId) {
+  const chat = chats.find((c) => c.id === chatId)
+  return chat ? chat.messages : []
+}


### PR DESCRIPTION
## Summary
- modularize chat page into components and services
- introduce router setup for future navigation
- add message service layer for mocking send/receive

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install react-router-dom@^6.22.3` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_689d0dac90bc832a96eac8d3ee009913