### PR TITLE
feat: add login and registration flow

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+
+export default function ProtectedRoute({ children }) {
+  const token = localStorage.getItem('authToken');
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}
+

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { login } from '../services/authService';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (localStorage.getItem('authToken')) {
+      navigate('/chat');
+    }
+  }, [navigate]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const { token } = await login(email, password);
+      localStorage.setItem('authToken', token);
+      navigate('/chat');
+    } catch (err) {
+      setError('Credenciales inválidas');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-md bg-white shadow-xl rounded-lg p-8">
+        <h1 className="text-2xl font-bold mb-6 text-center text-gray-800">Iniciar sesión</h1>
+        {error && <p className="text-red-500 mb-4 text-sm">{error}</p>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Email</label>
+            <input
+              type="email"
+              className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Contraseña</label>
+            <input
+              type="password"
+              className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full bg-indigo-600 text-white py-2 rounded-md hover:bg-indigo-700 transition-colors"
+          >
+            Entrar
+          </button>
+        </form>
+        <p className="text-center text-sm text-gray-600 mt-4">
+          ¿No tienes cuenta?{' '}
+          <Link to="/register" className="text-indigo-600 hover:underline">
+            Regístrate
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { register as registerUser } from '../services/authService';
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [phone, setPhone] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await registerUser(email, password, phone);
+      navigate('/login');
+    } catch (err) {
+      setError('No se pudo completar el registro');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-teal-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-md bg-white shadow-xl rounded-lg p-8">
+        <h1 className="text-2xl font-bold mb-6 text-center text-gray-800">Crear cuenta</h1>
+        {error && <p className="text-red-500 mb-4 text-sm">{error}</p>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Email</label>
+            <input
+              type="email"
+              className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Contraseña</label>
+            <input
+              type="password"
+              className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Teléfono de la empresa</label>
+            <input
+              type="tel"
+              className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full bg-teal-600 text-white py-2 rounded-md hover:bg-teal-700 transition-colors"
+          >
+            Registrarse
+          </button>
+        </form>
+        <p className="text-center text-sm text-gray-600 mt-4">
+          ¿Ya tienes cuenta?{' '}
+          <Link to="/login" className="text-teal-600 hover:underline">
+            Inicia sesión
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,10 +1,30 @@
-import React from 'react'
-import { createBrowserRouter } from 'react-router-dom'
-import ChatPage from '../pages/ChatPage'
+import React from 'react';
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import ChatPage from '../pages/ChatPage';
+import LoginPage from '../pages/LoginPage';
+import RegisterPage from '../pages/RegisterPage';
+import ProtectedRoute from '../components/ProtectedRoute';
 
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: <ChatPage />,
+    element: <Navigate to="/login" />,
   },
-])
+  {
+    path: '/login',
+    element: <LoginPage />, 
+  },
+  {
+    path: '/register',
+    element: <RegisterPage />, 
+  },
+  {
+    path: '/chat',
+    element: (
+      <ProtectedRoute>
+        <ChatPage />
+      </ProtectedRoute>
+    ),
+  },
+]);
+

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,34 @@
+const API_URL = 'http://localhost:3000/auth';
+
+export async function login(email, password) {
+  const response = await fetch(`${API_URL}/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Credenciales inválidas');
+  }
+
+  return response.json();
+}
+
+export async function register(email, password, phone) {
+  const response = await fetch(`${API_URL}/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password, phone }),
+  });
+
+  if (!response.ok) {
+    throw new Error('No se pudo registrar el usuario');
+  }
+
+  return response.json();
+}
+


### PR DESCRIPTION
## Summary
- add authentication service
- create login and register pages with professional Tailwind forms
- protect chat with auth-aware routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_689f886de22c832a888876fd99371fc7