### PR TITLE
feat: enhance login layout with branding

### DIFF
--- a/src/assets/orvex-logo.svg
+++ b/src/assets/orvex-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <polygon points="50,0 100,100 0,100" fill="#ff0000"/>
+  <polygon points="50,25 80,85 20,85" fill="#ffffff"/>
+  <polygon points="50,45 63,75 37,75" fill="#ff0000"/>
+</svg>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { login } from '../services/authService';
+import logo from '../assets/orvex-logo.svg';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -27,44 +28,53 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
-      <div className="w-full max-w-md bg-white shadow-xl rounded-lg p-8">
-        <h1 className="text-2xl font-bold mb-6 text-center text-gray-800">Iniciar sesión</h1>
-        {error && <p className="text-red-500 mb-4 text-sm">{error}</p>}
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Email</label>
-            <input
-              type="email"
-              className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">Contraseña</label>
-            <input
-              type="password"
-              className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
-          <button
-            type="submit"
-            className="w-full bg-indigo-600 text-white py-2 rounded-md hover:bg-indigo-700 transition-colors"
-          >
-            Entrar
-          </button>
-        </form>
-        <p className="text-center text-sm text-gray-600 mt-4">
-          ¿No tienes cuenta?{' '}
-          <Link to="/register" className="text-indigo-600 hover:underline">
-            Regístrate
-          </Link>
-        </p>
+    <div className="min-h-screen flex">
+      {/* Left branding section */}
+      <div className="hidden md:flex w-1/2 bg-gradient-to-b from-red-600 to-red-800 text-white flex-col items-center justify-center p-8">
+        <img src={logo} alt="Orvex Chat" className="w-40 h-40 mb-4" />
+        <h1 className="text-4xl font-bold">Orvex Chat</h1>
+        <p className="mt-2 text-lg text-red-100">Conecta y conversa al instante</p>
+      </div>
+      {/* Right login form */}
+      <div className="w-full md:w-1/2 flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+        <div className="w-full max-w-md bg-white shadow-xl rounded-lg p-8">
+          <h2 className="text-2xl font-bold mb-6 text-center text-gray-800">Iniciar sesión</h2>
+          {error && <p className="text-red-500 mb-4 text-sm">{error}</p>}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Email</label>
+              <input
+                type="email"
+                className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Contraseña</label>
+              <input
+                type="password"
+                className="mt-1 w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              className="w-full bg-indigo-600 text-white py-2 rounded-md hover:bg-indigo-700 transition-colors"
+            >
+              Entrar
+            </button>
+          </form>
+          <p className="text-center text-sm text-gray-600 mt-4">
+            ¿No tienes cuenta?{' '}
+            <Link to="/register" className="text-indigo-600 hover:underline">
+              Regístrate
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- revamp login page with split layout and branding section
- add SVG logo asset for Orvex Chat

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a096d3a39c832abde12e9be1ecc793