### PR TITLE
feat: add branded header and red themed chat

### DIFF
--- a/src/components/ChatHeader.jsx
+++ b/src/components/ChatHeader.jsx
@@ -1,0 +1,26 @@
+import { useNavigate } from "react-router-dom";
+import logo from "../assets/logo.png";
+
+export default function ChatHeader() {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem("authToken");
+    navigate("/");
+  };
+
+  return (
+    <header className="flex items-center justify-between bg-[#2D0303] text-white px-6 py-3 shadow-md">
+      <div className="flex items-center gap-3">
+        <img src={logo} alt="Orvex Chat Logo" className="h-10 w-auto" />
+        <span className="text-2xl font-bold tracking-wide">Orvex Chat</span>
+      </div>
+      <button
+        onClick={handleLogout}
+        className="bg-red-600 hover:bg-red-700 text-white font-semibold px-4 py-2 rounded-lg transition-colors"
+      >
+        Cerrar sesión
+      </button>
+    </header>
+  );
+}

--- a/src/components/ChatSidebar.jsx
+++ b/src/components/ChatSidebar.jsx
@@ -4,15 +4,15 @@ export default function ChatSidebar({ conversations, selectedId, onSelect }) {
   return (
     // Asegúrate de que la clase flex-col está en el aside
     // y que el aside tiene una altura definida (por ejemplo, a través de flexbox)
-    <aside className="w-80 bg-white shadow-lg rounded-lg overflow-hidden border border-gray-200 flex flex-col h-full">
-      <h2 className="p-5 text-xl font-semibold text-gray-900 border-b border-gray-200 bg-gray-50">
+    <aside className="w-80 bg-white shadow-lg border border-red-100 flex flex-col h-full">
+      <h2 className="p-5 text-xl font-semibold text-white border-b border-red-200 bg-[#2D0303]">
         Chats
       </h2>
-      <ul className="flex-1 overflow-y-auto divide-y divide-gray-200">
+      <ul className="flex-1 overflow-y-auto divide-y divide-red-100">
         {conversations.map((conv) => (
           <li
             key={conv.id}
-            className={`relative p-4 cursor-pointer transition-colors hover:bg-gray-50 ${selectedId === conv.id ? 'bg-gray-100' : ''} rounded-md focus:outline-none`}
+            className={`relative p-4 cursor-pointer transition-colors hover:bg-red-50 ${selectedId === conv.id ? 'bg-red-100': ''} rounded-md focus:outline-none`}
             onClick={() => onSelect(conv.id)}
           >
             <div className="flex justify-between items-center">

--- a/src/components/ChatWindow.jsx
+++ b/src/components/ChatWindow.jsx
@@ -17,15 +17,15 @@ export default function ChatWindow({
   }, [messages]);
 
   return (
-    <section className="flex-1 flex flex-col bg-gray-50 rounded-lg shadow-lg overflow-hidden">
-      <header className="p-5 border-b border-gray-200 flex justify-between items-center bg-white">
-        <h2 className="text-xl font-semibold text-gray-900">
+    <section className="flex-1 flex flex-col bg-white shadow-lg overflow-hidden">
+      <header className="p-5 border-b border-red-200 flex justify-between items-center bg-[#2D0303]">
+        <h2 className="text-xl font-semibold text-white">
           {chatId ? `Chat con ${chatId}` : 'Selecciona un chat'}
         </h2>
         {chatId && (
           <button
             className={`px-5 py-2 rounded-lg text-sm font-medium transition-colors duration-200 ${
-              isHumanControl ? 'bg-green-600 hover:bg-green-700' : 'bg-purple-600 hover:bg-purple-700'
+              isHumanControl ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'
             } text-white`}
             onClick={() => onToggleMode(isHumanControl ? 'IA' : 'humano')}
           >
@@ -34,7 +34,7 @@ export default function ChatWindow({
         )}
       </header>
 
-      <div className="flex-1 p-6 overflow-y-auto flex flex-col gap-4">
+      <div className="flex-1 p-6 overflow-y-auto flex flex-col gap-4 bg-red-50">
         {messages.length > 0 ? (
           messages.map((msg, index) => (
             <MessageItem key={msg.SK || `message-${index}`} message={msg} />
@@ -47,7 +47,7 @@ export default function ChatWindow({
         <div ref={messagesEndRef} />
       </div>
 
-      <footer className="p-5 border-t border-gray-200 bg-white">
+      <footer className="p-5 border-t border-red-200 bg-white">
         <MessageInput onSend={onSend} isDisabled={isSendDisabled && !isHumanControl} />
       </footer>
     </section>

--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import ChatSidebar from "../components/ChatSidebar";
 import ChatWindow from "../components/ChatWindow";
+import ChatHeader from "../components/ChatHeader";
 import { getChats, getMessages, sendMessage } from "../services/chatService";
 import {
   initSocket,
@@ -153,21 +154,23 @@ export default function ChatPage() {
   // ✅ El resto de tu componente permanece igual
 
   return (
-    // CAMBIO AQUÍ: min-h-screen a h-screen
-    <div className="h-screen bg-gradient-to-br from-gray-50 to-gray-100 flex">
-      <ChatSidebar
-        conversations={conversations}
-        selectedId={selectedConversationId}
-        onSelect={handleChatClick}
-      />
-      <ChatWindow
-        chatId={selectedConversationId}
-        messages={currentChatHistory}
-        isHumanControl={isHumanControl}
-        isSendDisabled={isSendDisabled}
-        onSend={handleSend}
-        onToggleMode={updateChatMode}
-      />
+    <div className="h-screen flex flex-col bg-gradient-to-br from-red-50 to-red-100">
+      <ChatHeader />
+      <div className="flex flex-1 overflow-hidden">
+        <ChatSidebar
+          conversations={conversations}
+          selectedId={selectedConversationId}
+          onSelect={handleChatClick}
+        />
+        <ChatWindow
+          chatId={selectedConversationId}
+          messages={currentChatHistory}
+          isHumanControl={isHumanControl}
+          isSendDisabled={isSendDisabled}
+          onSend={handleSend}
+          onToggleMode={updateChatMode}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add top header with logo and logout button
- apply red themed styling across chat sidebar and window
- restructure chat page layout to include header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b30da738832a9c0c292153f40ecd